### PR TITLE
fix export pdf notebook

### DIFF
--- a/doctr/export_as_pdfa.ipynb
+++ b/doctr/export_as_pdfa.ipynb
@@ -28,6 +28,8 @@
     "!pip3 install reportlab>=3.6.2\n",
     "# Optional if you want to merge multiple pdfs\n",
     "!pip3 install PyPDF2==1.26.0\n",
+    "# For matplotlib\n",
+    "!pip3 install mplcursors\n",
     "# Restart runtime\n",
     "exit()"
    ]
@@ -244,13 +246,21 @@
    "outputs": [],
    "source": [
     "# Download a sample\n",
-    "!wget https://www.allianzdirect.de/dam/documents/home/Versicherungsbedingungen-08-2021.pdf\n",
+    "!wget https://www.allianzdirect.de/dam/documents/home/Versicherungsbedingungen-08-2021.pdf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Read the file\n",
     "docs = DocumentFile.from_pdf(\"Versicherungsbedingungen-08-2021.pdf\")\n",
     "model = ocr_predictor(det_arch='db_resnet50', reco_arch='crnn_vgg16_bn', pretrained=True)\n",
     "# we will grab only the first two pages from the pdf for demonstration\n",
     "result = model(docs[:2])\n",
-    "result.show(docs)"
+    "result.show()"
    ]
   },
   {

--- a/doctr/export_as_pdfa.ipynb
+++ b/doctr/export_as_pdfa.ipynb
@@ -24,12 +24,10 @@
     "!sudo apt install libcairo2-dev pkg-config\n",
     "!pip3 install pycairo\n",
     "# Install doctr\n",
-    "!pip3 install python-doctr[tf]@git+https://github.com/mindee/doctr.git\n",
+    "!pip3 install python-doctr[tf,viz]@git+https://github.com/mindee/doctr.git\n",
     "!pip3 install reportlab>=3.6.2\n",
     "# Optional if you want to merge multiple pdfs\n",
     "!pip3 install PyPDF2==1.26.0\n",
-    "# For matplotlib\n",
-    "!pip3 install mplcursors\n",
     "# Restart runtime\n",
     "exit()"
    ]


### PR DESCRIPTION
Fixed the issue (https://github.com/mindee/doctr/issues/1596) with : 

* removed the now unnecessary argument from the show function
* added a pip install for mplcursors as it was suggested from the error


Code improvement : 
* split the cell that download the file and run the model into two cells since you don't want to download again the file if you want to rerun the model