### PR TITLE
Update quicktour.ipynb

### DIFF
--- a/doctr/quicktour.ipynb
+++ b/doctr/quicktour.ipynb
@@ -313,7 +313,7 @@
    },
    "outputs": [],
    "source": [
-    "result.show(doc)"
+    "result.show()"
    ]
   },
   {


### PR DESCRIPTION
Fixed result.show() call, as it was given an argument too much. 

CHANGE: 
result.show(doc) => result.show()

